### PR TITLE
Updating directives RegExp pattern to match current spec

### DIFF
--- a/grammars/graphql.cson
+++ b/grammars/graphql.cson
@@ -64,7 +64,7 @@
     'match': '\\d+\\.?\\d*[eE]?[\\+\\-]?\\d*'
   "directive":
     'name': 'storage.modifier'
-    'match': '@[a-z]+'
+    'match': '@[_A-Za-z][_0-9A-Za-z]+'
   "argument":
     'name': 'variable.parameter'
     'match': '[_A-Za-z][_0-9A-Za-z]*:'


### PR DESCRIPTION
Testing with graphql-js v0.7.0, directives are allowed to start with an underscore, or A-Z/a-z, and then can be followed by _, 0-9, a-z and A-Z.