### PR TITLE
Add graphqls filetype for schema definitions

### DIFF
--- a/grammars/graphql.json
+++ b/grammars/graphql.json
@@ -4,6 +4,7 @@
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "fileTypes": [
+    "graphqls",
     "graphql",
     "gql"
   ],


### PR DESCRIPTION
Adding 'graphqls' filetype for teams that use both Atom and Intellij editors. Intellij packages use the 'graphqls' filetype to signify GraphQL Schema files.