### PR TITLE
Add support for `.prisma` files

### DIFF
--- a/grammars/graphql.json
+++ b/grammars/graphql.json
@@ -4,6 +4,7 @@
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "fileTypes": [
+    "prisma",
     "graphqls",
     "graphql",
     "gql"


### PR DESCRIPTION
This PR adds support for files with the `.prisma` extension.  
These files use the same GraphQL syntax that traditional files do, except the they're used for [Prisma](https://www.prisma.io/).  