### PR TITLE
Fix definitions highlighting after field and variable

### DIFF
--- a/grammars/graphql.json
+++ b/grammars/graphql.json
@@ -119,7 +119,8 @@
         { "include": "#graphql-variable-definitions" },
         { "include": "#graphql-type-object" },
         { "include": "#graphql-colon"},
-        { "include": "#graphql-input-types"}
+        { "include": "#graphql-input-types"},
+        { "include": "#graphql-string-value"}
       ]
     },
     "graphql-schema": {
@@ -207,7 +208,8 @@
         { "include": "#graphql-colon" },
         { "include": "#graphql-input-types"},
         { "include": "#graphql-variable-assignment"},
-        { "include": "#graphql-skip-newlines" }
+        { "include": "#graphql-skip-newlines" },
+        { "include": "#graphql-string-value"}
       ]
     },
     "graphql-input-types": {


### PR DESCRIPTION
Before this change, description strings are not highlighted after:
* the first field in a type, 
* the first variable in a field.

![image](https://user-images.githubusercontent.com/1180536/67625611-9735ed80-f840-11e9-9efd-221ba9e0d6e2.png)

Descriptions for type fields and field variables are [explicitly allowed by the GraphQL spec](https://graphql.github.io/graphql-spec/draft/#sec-Descriptions).

This change fixes highlighting of string values in types and fields, according to the spec.
![image](https://user-images.githubusercontent.com/1180536/67625629-c9dfe600-f840-11e9-8a98-e2847a88e152.png)
